### PR TITLE
Handle centrifuge subscribing event

### DIFF
--- a/frontend/src/lib/stores/notificationStore.js
+++ b/frontend/src/lib/stores/notificationStore.js
@@ -44,6 +44,7 @@ export default function createStore() {
 			}
 		});
 		sub.on('subscribed', () => connected.set(true));
+		sub.on('subscribing', () => connected.set(false));
 		sub.on('unsubscribed', () => connected.set(false));
 		sub.on('error', () => connected.set(false));
 


### PR DESCRIPTION
In centrifuge-js v3 subscription can be in 3 states instead of 2. And during temporary connection loss subscription goes to `subscribing` state - because it's waiting for connection repair to resubscribe again. On `unsubscribed` will be called when you call `sub.unsubscribe()` or terminal condition met (so subscription won't try to resubscribe, this can happen in case of advice from a server or when backend returns an empty refresh token - which means user does not have permissions to subscribe on channel). So I think all transitions should be handled here.

From https://centrifugal.dev/docs/transports/client_api :

![image](https://user-images.githubusercontent.com/1196565/180273808-8a116c5e-7bcf-409c-9546-b47cfdde5d3e.png)
